### PR TITLE
Unable to install dhclient-12:4.2.5-68.el7

### DIFF
--- a/doc_source/inspector_walkthrough.md
+++ b/doc_source/inspector_walkthrough.md
@@ -26,6 +26,7 @@ For this tutorial, you modify your target EC2 instance to expose it to the poten
 Connect to your instance, **InspectorEC2InstanceLinux**, and run the following command:
 
 `sudo yum install dhclient-12:4.2.5-68.el7 `
+Not working
 
 For instructions on how to connect to an EC2 instance, see [Connect to Your Instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EC2_GetStarted.html#ec2-connect-to-instance-linux) in the *Amazon EC2 User Guide*\.
 


### PR DESCRIPTION
When using Amazon Linux AMI 2 to install dhclient-12:4.2.5-68.el7 using the command, sudo yum install dhclient-12:4.2.5-68.el7.
The output says, No package dhclient-12:4.2.5-68.el7 available.

Issue #, 
![image](https://user-images.githubusercontent.com/28826185/120598415-db995e80-c463-11eb-91e2-dc797a042354.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
