### PR TITLE
keep extension of inspector consistent

### DIFF
--- a/doc_source/inspector_verify-sig-agent-download-linux.md
+++ b/doc_source/inspector_verify-sig-agent-download-linux.md
@@ -33,7 +33,7 @@ The next step in the process is to authenticate the Amazon Inspector public key 
 
 1. Obtain a copy of our public `GPG` build key by doing one of the following:
    + Download from [https://d1wk0tztpsntt1\.cloudfront\.net/linux/latest/inspector\.gpg](https://d1wk0tztpsntt1.cloudfront.net/linux/latest/inspector.gpg)\.
-   + Copy the key from the following text and paste it into a file called `inspector.key`\. Make sure to include everything that follows:
+   + Copy the key from the following text and paste it into a file called `inspector.gpg`\. Make sure to include everything that follows:
 
      ```
      -----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -67,10 +67,10 @@ The next step in the process is to authenticate the Amazon Inspector public key 
      -----END PGP PUBLIC KEY BLOCK-----
      ```
 
-1. At a command prompt in the directory where you saved **inspector\.key**, use the following command to import the Amazon Inspector public key into your keyring:
+1. At a command prompt in the directory where you saved **inspector\.gpg**, use the following command to import the Amazon Inspector public key into your keyring:
 
    ```
-   gpg --import inspector.key
+   gpg --import inspector.gpg
    ```
 
    The command returns results that are similar to the following:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Updated the extension of inspector gpg key to be consistent. For people downloading using curl and copy pasting the import command you get an error as the file inspector.key does not exist.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
