### PR TITLE
use a safer url for Inspector Agent download

### DIFF
--- a/doc_source/inspector_agents-on-win.md
+++ b/doc_source/inspector_agents-on-win.md
@@ -50,7 +50,7 @@ Complete one of the following procedures:
 
 **To install an agent on an EC2 instance that uses a proxy server**
 
-1. Download the following \.exe file: `https://d1wk0tztpsntt1.cloudfront.net/windows/installer/latest/AWSAgentInstall.exe`\.
+1. Download the following \.exe file: `https://inspector-agent.amazonaws.com/windows/installer/latest/AWSAgentInstall.exe`\.
 
 1. Open a command prompt window or PowerShell window \(using administrative permissions\)\. Navigate to the location where you saved the downloaded `AWSAgentInstall.exe`, and then run the following command:
 


### PR DESCRIPTION
*Description of changes:*

The "Installing Amazon Inspector Classic agents" document uses this url already, and the downloaded files appear to be identical.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
