### PR TITLE
docs: add partition to arn

### DIFF
--- a/doc_source/inspector-arns-resources.md
+++ b/doc_source/inspector-arns-resources.md
@@ -5,8 +5,8 @@ In Amazon Inspector, the primary resources are resource groups, assessment targe
 
 | Resource Type | ARN Format  | 
 | --- | --- | 
-| Resource group |  `arn:aws:inspector:region:account-id:resourcegroup/ID`  | 
-| Assessment target |  `arn:aws:inspector:region:account-id:target/ID `  | 
-| Assessment template |  `arn:aws:inspector:region:account-id:target/ID:template:ID`  | 
-| Assessment run |  `arn:aws:inspector:region:account-id:target/ID/template/ID/run/ID`  | 
-| Finding |  `arn:aws:inspector:region:account-id:target/ID/template/ID/run/ID/finding/ID`  | 
+| Resource group |  `arn:partition:inspector:region:account-id:resourcegroup/ID`  | 
+| Assessment target |  `arn:partition:inspector:region:account-id:target/ID `  | 
+| Assessment template |  `arn:partition:inspector:region:account-id:target/ID:template:ID`  | 
+| Assessment run |  `arn:partition:inspector:region:account-id:target/ID/template/ID/run/ID`  | 
+| Finding |  `arn:partition:inspector:region:account-id:target/ID/template/ID/run/ID/finding/ID`  | 


### PR DESCRIPTION
I'm running into an issue with event bridge running an inspector template. It says `Template InspectorTemplate was not found.` I think this is probably because of an issue parsing the partition. So I looked at the docs and you have `aws` hardcoded as the partition in the docs. I hope this isn't the only acceptable format. If it is not than the docs should be updated.

![image](https://user-images.githubusercontent.com/19394493/192321821-8d5b831d-62f0-4b6f-aa20-dbc6f3be00fb.png)




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
